### PR TITLE
Replace deprecated :unprocessable_entity with :unprocessable_content

### DIFF
--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -20,7 +20,7 @@ class GalleriesController < ApplicationController
     if @gallery.save
       redirect_to @gallery, notice: "Gallery was successfully created."
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -31,7 +31,7 @@ class GalleriesController < ApplicationController
     if @gallery.update(gallery_params)
       redirect_to @gallery, notice: "Gallery was successfully updated."
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/public_photos_controller.rb
+++ b/app/controllers/public_photos_controller.rb
@@ -33,7 +33,7 @@ class PublicPhotosController < ApplicationController
     if @upload.update(upload_params)
       render json: { success: true, is_public: @upload.is_public }
     else
-      render json: { success: false, errors: @upload.errors.full_messages }, status: :unprocessable_entity
+      render json: { success: false, errors: @upload.errors.full_messages }, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/slideshows_controller.rb
+++ b/app/controllers/slideshows_controller.rb
@@ -52,7 +52,7 @@ class SlideshowsController < ApplicationController
     if @slideshow.save
       render json: { id: @slideshow.id, redirect: slideshow_path(@slideshow) }
     else
-      render json: { errors: @slideshow.errors.full_messages }, status: :unprocessable_entity
+      render json: { errors: @slideshow.errors.full_messages }, status: :unprocessable_content
     end
   end
 
@@ -65,7 +65,7 @@ class SlideshowsController < ApplicationController
     if @slideshow.update(slideshow_params)
       redirect_to slideshow_path(@slideshow), notice: "Slideshow updated"
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/spotify_controller.rb
+++ b/app/controllers/spotify_controller.rb
@@ -20,7 +20,7 @@ class SpotifyController < ApplicationController
     result = service.search(query, type: type)
 
     if result[:error]
-      render json: { error: result[:error] }, status: :unprocessable_entity
+      render json: { error: result[:error] }, status: :unprocessable_content
     else
       render json: result
     end

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -37,8 +37,8 @@ class UploadsController < ApplicationController
         format.json { render json: { success: true, message: message }, status: :ok }
       else
         format.html { redirect_to @gallery, alert: "Failed to upload files: #{errors.join(', ')}" }
-        format.turbo_stream { head :unprocessable_entity }
-        format.json { render json: { success: false, errors: errors }, status: :unprocessable_entity }
+        format.turbo_stream { head :unprocessable_content }
+        format.json { render json: { success: false, errors: errors }, status: :unprocessable_content }
       end
     end
   end
@@ -54,7 +54,7 @@ class UploadsController < ApplicationController
         short_code: @upload.short_code
       }
     else
-      render json: { success: false, errors: @upload.errors.full_messages }, status: :unprocessable_entity
+      render json: { success: false, errors: @upload.errors.full_messages }, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -15,7 +15,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
         bypass_sign_in resource, scope: resource_name
         redirect_to edit_user_registration_path, notice: "Settings updated successfully."
       else
-        render :edit, status: :unprocessable_entity
+        render :edit, status: :unprocessable_content
       end
     else
       # Changing password requires current password

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -302,7 +302,7 @@ Devise.setup do |config|
   # apps is `200 OK` and `302 Found` respectively, but new apps are generated with
   # these new defaults that match Hotwire/Turbo behavior.
   # Note: These might become the new default in future versions of Devise.
-  config.responder.error_status = :unprocessable_entity
+  config.responder.error_status = :unprocessable_content
   config.responder.redirect_status = :see_other
 
   # ==> Configuration for :registerable

--- a/spec/requests/galleries_spec.rb
+++ b/spec/requests/galleries_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Galleries", type: :request do
       post "/galleries",
         params: { gallery: { title: "", description: "Test" } },
         headers: { "Accept" => "text/vnd.turbo-stream.html, text/html" }
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes Rack deprecation warning: `:unprocessable_entity` is deprecated and will be removed in a future version. This PR replaces all occurrences with `:unprocessable_content` (same HTTP 422 status code).

## Changes

- Updated 6 controllers to use `:unprocessable_content`
- Updated Devise config error status
- Updated request spec to expect new status symbol

## Type of Change

- [x] Chore (dependencies, CI, etc.)

## Testing

- All 113 existing tests pass
- RuboCop: no offenses
- Brakeman: no security warnings