### PR TITLE
🐛 Fix upload factory to use real test image

### DIFF
--- a/spec/factories/uploads.rb
+++ b/spec/factories/uploads.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
 
     after(:build) do |upload|
       upload.file.attach(
-        io: StringIO.new("fake image data"),
+        io: Rails.root.join("spec/fixtures/files/test_image.jpg").open,
         filename: "test_image.jpg",
         content_type: "image/jpeg"
       )


### PR DESCRIPTION
## Summary
- Fixed failing test in `public_photos_spec.rb` by using a real image file in the upload factory
- The factory was using `StringIO.new("fake image data")` which caused `ActiveStorage::UnpreviewableError` when tests tried to process image variants

## Test plan
- [x] `bundle exec rspec` - all 146 tests pass
- [x] `bundle exec rubocop` - no offenses
- [x] `bundle exec brakeman` - no warnings