### PR TITLE
⚡ Fix N+1 queries in slideshow controllers

### DIFF
--- a/app/controllers/public_slideshows_controller.rb
+++ b/app/controllers/public_slideshows_controller.rb
@@ -6,7 +6,7 @@ class PublicSlideshowsController < ApplicationController
   def show
     @slideshow = Slideshow.find_by!(short_code: params[:short_code])
     @slideshow.increment!(:view_count)
-    @uploads = @slideshow.uploads
+    @uploads = @slideshow.uploads.with_file
 
     @images_data = @uploads.select { |u| u.file.attached? }.map.with_index do |u, i|
       {

--- a/app/controllers/slideshows_controller.rb
+++ b/app/controllers/slideshows_controller.rb
@@ -17,7 +17,7 @@ class SlideshowsController < ApplicationController
     else
       current_user.slideshows.find(params[:id])
     end
-    @uploads = @slideshow.uploads
+    @uploads = @slideshow.uploads.with_file
 
     @images_data = @uploads.select { |u| u.file.attached? }.map.with_index do |u, i|
       {

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -34,6 +34,7 @@ class Upload < ApplicationRecord
   scope :videos, -> { where("uploads.file_content_type LIKE ?", "video/%") }
   scope :publicly_visible, -> { where(is_public: true) }
   scope :from_import, -> { where.not(import_id: nil) }
+  scope :with_file, -> { includes(file_attachment: :blob) }
 
   # Import helpers
   def imported?

--- a/db/migrate/20260301103950_add_user_gallery_index_to_uploads.rb
+++ b/db/migrate/20260301103950_add_user_gallery_index_to_uploads.rb
@@ -1,0 +1,9 @@
+class AddUserGalleryIndexToUploads < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :uploads, [ :user_id, :gallery_id, :created_at ],
+              name: "index_uploads_on_user_gallery_created",
+              algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1595,6 +1595,13 @@ CREATE UNIQUE INDEX index_uploads_on_short_code ON public.uploads USING btree (s
 
 
 --
+-- Name: index_uploads_on_user_gallery_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_uploads_on_user_gallery_created ON public.uploads USING btree (user_id, gallery_id, created_at);
+
+
+--
 -- Name: index_uploads_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1790,6 +1797,7 @@ ALTER TABLE ONLY public.galleries
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260301103950'),
 ('20260222182333'),
 ('20260222100000'),
 ('20260222095947'),

--- a/spec/factories/uploads.rb
+++ b/spec/factories/uploads.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
 
     after(:build) do |upload|
       upload.file.attach(
-        io: StringIO.new("fake image data"),
+        io: Rails.root.join("spec/fixtures/files/test_image.jpg").open,
         filename: "test_image.jpg",
         content_type: "image/jpeg"
       )


### PR DESCRIPTION
## Summary
- Add `with_file` scope to Upload model for eager loading Active Storage attachments
- Fix N+1 queries in `public_slideshows_controller` and `slideshows_controller`
- Add composite index on `uploads (user_id, gallery_id, created_at)` for future photo picker UI
- Fix upload factory to use real test image fixture

## Performance improvement
Before: 14 queries for 13 uploads (1 per attachment)
After: 3 queries total (uploads + attachments + blobs in batch)

## Test plan
- [x] `bundle exec rspec` - 146 tests pass
- [x] `bundle exec rubocop` - no offenses
- [x] `bundle exec brakeman` - no warnings