### PR TITLE
✨ Add photo picker for adding images to slideshows

### DIFF
--- a/app/javascript/controllers/photo_picker_controller.js
+++ b/app/javascript/controllers/photo_picker_controller.js
@@ -1,0 +1,502 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [
+    "modal",
+    "searchInput",
+    "slideshowList",
+    "filmstrip",
+    "zoomPreview",
+    "selectedCount",
+    "createForm",
+    "createTitleInput",
+    "createDescriptionInput"
+  ]
+  static values = {
+    images: Array
+  }
+
+  connect() {
+    this.selectedIds = new Set()
+    this.searchTimeout = null
+    this.longPressTimeout = null
+    this.isLongPress = false
+    this.showingCreateForm = false
+  }
+
+  disconnect() {
+    if (this.searchTimeout) clearTimeout(this.searchTimeout)
+    if (this.longPressTimeout) clearTimeout(this.longPressTimeout)
+  }
+
+  open(event) {
+    if (event) event.preventDefault()
+
+    if (this.imagesValue.length === 0) {
+      alert("No photos in this gallery")
+      return
+    }
+
+    this.selectedIds.clear()
+    this.renderFilmstrip()
+    this.updateSelectedCount()
+    this.searchSlideshows("")
+    this.modalTarget.classList.remove("hidden")
+    document.body.style.overflow = "hidden"
+    this.searchInputTarget.focus()
+  }
+
+  close(event) {
+    if (event) event.preventDefault()
+    this.modalTarget.classList.add("hidden")
+    document.body.style.overflow = ""
+    this.hideZoom()
+  }
+
+  renderFilmstrip() {
+    const html = this.imagesValue.map((img, index) => `
+      <div class="filmstrip-item relative flex-shrink-0 cursor-pointer transition-transform duration-150"
+           data-index="${index}"
+           data-id="${img.id}"
+           data-action="click->photo-picker#toggleSelect mouseenter->photo-picker#showZoom mouseleave->photo-picker#hideZoom touchstart->photo-picker#touchStart touchend->photo-picker#touchEnd touchmove->photo-picker#touchMove">
+        <img src="${img.thumb_webp || img.thumb}"
+             alt="${img.title || ''}"
+             class="h-20 w-20 object-cover rounded-lg border-2 border-transparent transition-all duration-150"
+             data-full="${img.large_webp || img.large || img.medium}"
+             draggable="false">
+        <div class="check-overlay absolute inset-0 bg-blue-500/30 rounded-lg opacity-0 transition-opacity flex items-center justify-center">
+          <svg class="w-8 h-8 text-white drop-shadow-lg" fill="currentColor" viewBox="0 0 20 20">
+            <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+          </svg>
+        </div>
+      </div>
+    `).join("")
+
+    this.filmstripTarget.innerHTML = html
+  }
+
+  toggleSelect(event) {
+    // Don't toggle if this was a long press (preview)
+    if (this.isLongPress) {
+      this.isLongPress = false
+      return
+    }
+
+    const item = event.currentTarget
+    const id = parseInt(item.dataset.id)
+    const img = item.querySelector("img")
+    const overlay = item.querySelector(".check-overlay")
+
+    if (this.selectedIds.has(id)) {
+      this.selectedIds.delete(id)
+      img.classList.remove("border-blue-500", "scale-95")
+      img.classList.add("border-transparent")
+      overlay.classList.add("opacity-0")
+    } else {
+      this.selectedIds.add(id)
+      img.classList.add("border-blue-500", "scale-95")
+      img.classList.remove("border-transparent")
+      overlay.classList.remove("opacity-0")
+    }
+
+    this.updateSelectedCount()
+  }
+
+  updateSelectedCount() {
+    const count = this.selectedIds.size
+    this.selectedCountTarget.textContent = count === 0
+      ? "Tap photos to select"
+      : `${count} photo${count === 1 ? "" : "s"} selected`
+  }
+
+  // Desktop: hover to zoom
+  showZoom(event) {
+    if ("ontouchstart" in window) return // Skip on touch devices
+
+    const item = event.currentTarget
+    const img = item.querySelector("img")
+    const fullSrc = img.dataset.full
+
+    this.zoomPreviewTarget.innerHTML = `
+      <img src="${fullSrc}" class="max-h-48 max-w-xs rounded-lg shadow-2xl object-contain">
+    `
+    this.zoomPreviewTarget.classList.remove("hidden", "opacity-0")
+    this.zoomPreviewTarget.classList.add("opacity-100")
+  }
+
+  hideZoom() {
+    this.zoomPreviewTarget.classList.add("opacity-0")
+    setTimeout(() => {
+      if (this.zoomPreviewTarget.classList.contains("opacity-0")) {
+        this.zoomPreviewTarget.classList.add("hidden")
+      }
+    }, 150)
+  }
+
+  // Mobile: long press to zoom
+  touchStart(event) {
+    this.touchStartX = event.touches[0].clientX
+    this.touchStartY = event.touches[0].clientY
+
+    this.longPressTimeout = setTimeout(() => {
+      this.isLongPress = true
+      const item = event.currentTarget
+      const img = item.querySelector("img")
+      const fullSrc = img.dataset.full
+
+      this.zoomPreviewTarget.innerHTML = `
+        <img src="${fullSrc}" class="max-h-64 max-w-sm rounded-lg shadow-2xl object-contain">
+      `
+      this.zoomPreviewTarget.classList.remove("hidden", "opacity-0")
+      this.zoomPreviewTarget.classList.add("opacity-100")
+
+      // Vibrate if supported
+      if (navigator.vibrate) navigator.vibrate(50)
+    }, 500)
+  }
+
+  touchMove(event) {
+    // Cancel long press if finger moves
+    const dx = Math.abs(event.touches[0].clientX - this.touchStartX)
+    const dy = Math.abs(event.touches[0].clientY - this.touchStartY)
+    if (dx > 10 || dy > 10) {
+      clearTimeout(this.longPressTimeout)
+    }
+  }
+
+  touchEnd() {
+    clearTimeout(this.longPressTimeout)
+    this.hideZoom()
+  }
+
+  // Slideshow search
+  handleSearch(event) {
+    const query = event.target.value.trim()
+
+    if (this.searchTimeout) clearTimeout(this.searchTimeout)
+
+    this.searchTimeout = setTimeout(() => {
+      this.searchSlideshows(query)
+    }, 300)
+  }
+
+  async searchSlideshows(query) {
+    try {
+      const url = `/slideshows/search?q=${encodeURIComponent(query)}`
+      const response = await fetch(url, {
+        headers: { "Accept": "application/json" }
+      })
+
+      if (!response.ok) throw new Error("Search failed")
+
+      const slideshows = await response.json()
+      this.renderSlideshowList(slideshows)
+    } catch (error) {
+      console.error("Search error:", error)
+      this.slideshowListTarget.innerHTML = `
+        <p class="text-red-500 text-sm p-4">Failed to load slideshows</p>
+      `
+    }
+  }
+
+  renderSlideshowList(slideshows) {
+    // Create new card always appears first
+    const createCard = `
+      <div class="flex-shrink-0 w-48" data-photo-picker-target="createForm">
+        <button type="button"
+                class="create-new-card w-full bg-gradient-to-br from-blue-600 to-blue-700 hover:from-blue-500 hover:to-blue-600 rounded-xl overflow-hidden transition-all duration-200 hover:scale-105 text-left"
+                data-action="click->photo-picker#showCreateForm">
+          <div class="aspect-video flex items-center justify-center">
+            <div class="text-center">
+              <svg class="w-10 h-10 text-white/80 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+              </svg>
+              <span class="text-white/90 text-sm font-medium">Create New</span>
+            </div>
+          </div>
+          <div class="p-3">
+            <p class="font-medium text-white/80 text-sm">New Slideshow</p>
+            <p class="text-xs text-white/50">Add selected photos</p>
+          </div>
+        </button>
+      </div>
+    `
+
+    if (slideshows.length === 0) {
+      this.slideshowListTarget.innerHTML = createCard + `
+        <div class="flex-shrink-0 flex items-center justify-center w-48 h-full text-white/40 text-center text-sm px-4">
+          <span>No existing slideshows yet</span>
+        </div>
+      `
+      return
+    }
+
+    const slideshowCards = slideshows.map(s => `
+      <button type="button"
+              class="slideshow-card flex-shrink-0 w-48 bg-white/10 hover:bg-white/20 rounded-xl overflow-hidden transition-all duration-200 hover:scale-105 text-left"
+              data-action="click->photo-picker#addToSlideshow"
+              data-slideshow-id="${s.id}"
+              data-slideshow-title="${s.title}">
+        <div class="aspect-video bg-neutral-800 relative">
+          ${s.cover_url
+            ? `<img src="${s.cover_url}" class="w-full h-full object-cover">`
+            : `<div class="w-full h-full flex items-center justify-center">
+                 <svg class="w-12 h-12 text-white/20" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+                 </svg>
+               </div>`
+          }
+          <div class="absolute bottom-2 right-2 bg-blue-600 rounded-full p-1.5 shadow-lg">
+            <svg class="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+            </svg>
+          </div>
+        </div>
+        <div class="p-3">
+          <p class="font-medium text-white truncate text-sm">${s.title}</p>
+          <p class="text-xs text-white/50">${s.photo_count} photo${s.photo_count === 1 ? "" : "s"}</p>
+        </div>
+      </button>
+    `).join("")
+
+    this.slideshowListTarget.innerHTML = createCard + slideshowCards
+  }
+
+  showCreateForm(event) {
+    event.preventDefault()
+    event.stopPropagation()
+
+    if (this.selectedIds.size === 0) {
+      alert("Please select at least one photo first")
+      return
+    }
+
+    // Show centered modal overlay
+    this.createFormTarget.innerHTML = `
+      <div class="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 backdrop-blur-sm"
+           data-action="click->photo-picker#cancelCreate">
+        <div class="bg-white rounded-2xl overflow-hidden shadow-2xl w-full max-w-md mx-4"
+             data-action="click->photo-picker#stopPropagation">
+          <div class="bg-gradient-to-r from-blue-600 to-blue-700 px-6 py-4">
+            <h3 class="text-white font-semibold text-lg">Create New Slideshow</h3>
+            <p class="text-white/70 text-sm">${this.selectedIds.size} photo${this.selectedIds.size === 1 ? '' : 's'} selected</p>
+          </div>
+          <div class="p-6 space-y-4">
+            <div>
+              <label class="block text-sm font-medium text-neutral-700 mb-2">Title *</label>
+              <input type="text"
+                     data-photo-picker-target="createTitleInput"
+                     placeholder="Enter slideshow title..."
+                     class="w-full px-4 py-3 text-base border border-neutral-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                     required>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-neutral-700 mb-2">Description *</label>
+              <textarea data-photo-picker-target="createDescriptionInput"
+                        placeholder="Add a short description..."
+                        rows="3"
+                        class="w-full px-4 py-3 text-base border border-neutral-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none"
+                        required></textarea>
+            </div>
+            <div class="flex gap-3 pt-2">
+              <button type="button"
+                      data-action="click->photo-picker#cancelCreate"
+                      class="flex-1 px-4 py-3 text-base font-medium text-neutral-700 bg-neutral-100 hover:bg-neutral-200 rounded-xl transition-colors">
+                Cancel
+              </button>
+              <button type="button"
+                      data-action="click->photo-picker#createSlideshow"
+                      class="flex-1 px-4 py-3 text-base font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-xl transition-colors">
+                Create Slideshow
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    `
+
+    this.showingCreateForm = true
+    // Focus the title input
+    setTimeout(() => {
+      if (this.hasCreateTitleInputTarget) {
+        this.createTitleInputTarget.focus()
+      }
+    }, 100)
+  }
+
+  cancelCreate(event) {
+    if (event) {
+      event.preventDefault()
+      event.stopPropagation()
+    }
+    this.showingCreateForm = false
+    // Clear the modal and restore the create card
+    if (this.hasCreateFormTarget) {
+      this.createFormTarget.innerHTML = `
+        <button type="button"
+                class="create-new-card w-full bg-gradient-to-br from-blue-600 to-blue-700 hover:from-blue-500 hover:to-blue-600 rounded-xl overflow-hidden transition-all duration-200 hover:scale-105 text-left"
+                data-action="click->photo-picker#showCreateForm">
+          <div class="aspect-video flex items-center justify-center">
+            <div class="text-center">
+              <svg class="w-10 h-10 text-white/80 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+              </svg>
+              <span class="text-white/90 text-sm font-medium">Create New</span>
+            </div>
+          </div>
+          <div class="p-3">
+            <p class="font-medium text-white/80 text-sm">New Slideshow</p>
+            <p class="text-xs text-white/50">Add selected photos</p>
+          </div>
+        </button>
+      `
+    }
+  }
+
+  async createSlideshow(event) {
+    event.preventDefault()
+    event.stopPropagation()
+
+    const title = this.createTitleInputTarget.value.trim()
+    const description = this.createDescriptionInputTarget.value.trim()
+
+    if (!title) {
+      this.createTitleInputTarget.focus()
+      this.createTitleInputTarget.classList.add("border-red-500")
+      return
+    }
+
+    if (!description) {
+      this.createDescriptionInputTarget.focus()
+      this.createDescriptionInputTarget.classList.add("border-red-500")
+      return
+    }
+
+    const formData = new FormData()
+    formData.append('slideshow[title]', title)
+    formData.append('slideshow[description]', description)
+    formData.append('slideshow[interval]', 5)
+
+    // Add selected upload IDs
+    this.selectedIds.forEach(id => {
+      formData.append('upload_ids[]', id)
+    })
+
+    try {
+      const response = await fetch('/slideshows', {
+        method: 'POST',
+        headers: {
+          'X-CSRF-Token': document.querySelector('[name="csrf-token"]').content
+        },
+        body: formData
+      })
+
+      const result = await response.json()
+
+      if (response.ok) {
+        this.showToast(`Created "${title}" with ${this.selectedIds.size} photos`, "success")
+
+        // Clear selection
+        this.selectedIds.clear()
+        this.renderFilmstrip()
+        this.updateSelectedCount()
+
+        // Close modal and refresh slideshow list to show the new one
+        this.showingCreateForm = false
+        this.cancelCreate() // Restore the create card
+        this.searchSlideshows(this.searchInputTarget.value.trim())
+      } else {
+        this.showToast(result.errors ? result.errors.join(", ") : "Failed to create slideshow", "error")
+      }
+    } catch (error) {
+      console.error("Create error:", error)
+      this.showToast("Failed to create slideshow", "error")
+    }
+  }
+
+  async addToSlideshow(event) {
+    event.preventDefault()
+
+    if (this.selectedIds.size === 0) {
+      alert("Please select at least one photo first")
+      return
+    }
+
+    const button = event.currentTarget
+    const slideshowId = button.dataset.slideshowId
+    const slideshowTitle = button.dataset.slideshowTitle
+
+    // Disable button while processing
+    button.disabled = true
+    button.classList.add("opacity-50")
+
+    try {
+      const response = await fetch(`/slideshows/${slideshowId}/add_uploads`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": document.querySelector('[name="csrf-token"]').content
+        },
+        body: JSON.stringify({
+          upload_ids: Array.from(this.selectedIds)
+        })
+      })
+
+      const result = await response.json()
+
+      if (response.ok) {
+        // Show success feedback
+        const count = result.added_count
+        const message = count === 0
+          ? "Photos already in slideshow"
+          : `Added ${count} photo${count === 1 ? "" : "s"} to "${slideshowTitle}"`
+
+        this.showToast(message, count > 0 ? "success" : "info")
+
+        // Clear selection after successful add
+        this.selectedIds.clear()
+        this.renderFilmstrip()
+        this.updateSelectedCount()
+      } else {
+        this.showToast(result.error || "Failed to add photos", "error")
+      }
+    } catch (error) {
+      console.error("Add error:", error)
+      this.showToast("Failed to add photos", "error")
+    } finally {
+      button.disabled = false
+      button.classList.remove("opacity-50")
+    }
+  }
+
+  showToast(message, type = "success") {
+    const colors = {
+      success: "bg-green-600",
+      error: "bg-red-600",
+      info: "bg-blue-600"
+    }
+
+    const toast = document.createElement("div")
+    toast.className = `fixed bottom-24 left-1/2 -translate-x-1/2 px-4 py-2 rounded-lg text-white text-sm font-medium shadow-lg z-[60] ${colors[type]}`
+    toast.textContent = message
+    document.body.appendChild(toast)
+
+    setTimeout(() => {
+      toast.classList.add("opacity-0", "transition-opacity")
+      setTimeout(() => toast.remove(), 300)
+    }, 2500)
+  }
+
+  // Keyboard handling
+  keydown(event) {
+    if (this.modalTarget.classList.contains("hidden")) return
+
+    if (event.key === "Escape") {
+      this.close()
+    }
+  }
+
+  stopPropagation(event) {
+    event.stopPropagation()
+  }
+}

--- a/app/views/galleries/show.html.erb
+++ b/app/views/galleries/show.html.erb
@@ -21,13 +21,14 @@
 %>
 
 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8"
-     data-controller="lightbox slideshow"
+     data-controller="lightbox slideshow photo-picker"
      data-lightbox-images-value="<%= images_data.to_json %>"
      data-lightbox-can-edit-value="<%= can_edit %>"
      data-slideshow-images-value="<%= images_data.to_json %>"
      data-slideshow-gallery-title-value="<%= @gallery.title %>"
      data-slideshow-gallery-description-value="<%= @gallery.description %>"
-     data-action="keydown@window->lightbox#keydown keydown@window->slideshow#keydown">
+     data-photo-picker-images-value="<%= images_data.to_json %>"
+     data-action="keydown@window->lightbox#keydown keydown@window->slideshow#keydown keydown@window->photo-picker#keydown">
 
   <div class="mb-6">
     <%= link_to galleries_path, class: "inline-flex items-center text-sm text-neutral-500 hover:text-neutral-800 transition-colors" do %>
@@ -71,6 +72,10 @@
               <button data-action="click->slideshow#openSaveModal click->dropdown#close" class="w-full text-left px-4 py-2 text-sm text-neutral-700 hover:bg-neutral-50 flex items-center gap-2">
                 <span>💾</span>
                 <span>Save</span>
+              </button>
+              <button data-action="click->photo-picker#open click->dropdown#close" class="w-full text-left px-4 py-2 text-sm text-neutral-700 hover:bg-neutral-50 flex items-center gap-2">
+                <span>➕</span>
+                <span>Add to...</span>
               </button>
             </div>
           </div>
@@ -413,6 +418,70 @@
       </div>
     </div>
   </div>
+
+  <!-- Photo Picker Modal -->
+  <div data-photo-picker-target="modal"
+       data-action="click->photo-picker#close"
+       class="hidden fixed inset-0 z-50 bg-black/95 flex flex-col">
+
+    <!-- Header -->
+    <div class="flex-shrink-0 p-4 flex items-center justify-between border-b border-white/10"
+         data-action="click->photo-picker#stopPropagation">
+      <button data-action="click->photo-picker#close"
+              class="p-2 text-white/70 hover:text-white transition-colors rounded-lg hover:bg-white/10">
+        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+        </svg>
+      </button>
+      <h2 class="text-white text-lg font-medium">Add to Slideshow</h2>
+      <div class="w-10"></div>
+    </div>
+
+    <!-- Search and Slideshow Strip -->
+    <div class="flex-1 flex flex-col justify-center p-4" data-action="click->photo-picker#stopPropagation">
+      <!-- Search -->
+      <div class="max-w-md mx-auto w-full mb-6">
+        <div class="relative">
+          <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-white/40" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+          </svg>
+          <input type="text"
+                 data-photo-picker-target="searchInput"
+                 data-action="input->photo-picker#handleSearch"
+                 placeholder="Search slideshows..."
+                 class="w-full pl-10 pr-4 py-3 bg-white/10 border border-white/20 rounded-xl text-white placeholder-white/50 focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40">
+        </div>
+      </div>
+
+      <!-- Slideshow Horizontal Strip -->
+      <div class="relative">
+        <div data-photo-picker-target="slideshowList"
+             class="flex gap-4 overflow-x-auto pb-4 px-4 scroll-smooth snap-x"
+             style="-webkit-overflow-scrolling: touch;">
+          <!-- Populated by JS -->
+        </div>
+      </div>
+    </div>
+
+    <!-- Zoom Preview (appears above filmstrip on hover) -->
+    <div data-photo-picker-target="zoomPreview"
+         class="hidden opacity-0 transition-opacity duration-150 absolute bottom-32 left-1/2 -translate-x-1/2 pointer-events-none z-10">
+    </div>
+
+    <!-- Filmstrip -->
+    <div class="flex-shrink-0 border-t border-white/10 p-4" data-action="click->photo-picker#stopPropagation">
+      <p data-photo-picker-target="selectedCount" class="text-white/60 text-sm text-center mb-3">
+        Tap photos to select
+      </p>
+      <div class="relative">
+        <div data-photo-picker-target="filmstrip"
+             class="flex gap-2 overflow-x-auto pb-2 px-2 scroll-smooth snap-x snap-mandatory"
+             style="-webkit-overflow-scrolling: touch;">
+          <!-- Populated by JS -->
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <style>
@@ -451,5 +520,40 @@
   @keyframes zoomIn {
     from { transform: scale(1.05); opacity: 0; }
     to { transform: scale(1); opacity: 1; }
+  }
+
+  /* Photo picker scrollable strips */
+  [data-photo-picker-target="filmstrip"],
+  [data-photo-picker-target="slideshowList"] {
+    scrollbar-width: thin;
+    scrollbar-color: rgba(255,255,255,0.3) transparent;
+  }
+  [data-photo-picker-target="filmstrip"]::-webkit-scrollbar,
+  [data-photo-picker-target="slideshowList"]::-webkit-scrollbar {
+    height: 6px;
+  }
+  [data-photo-picker-target="filmstrip"]::-webkit-scrollbar-track,
+  [data-photo-picker-target="slideshowList"]::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  [data-photo-picker-target="filmstrip"]::-webkit-scrollbar-thumb,
+  [data-photo-picker-target="slideshowList"]::-webkit-scrollbar-thumb {
+    background: rgba(255,255,255,0.3);
+    border-radius: 3px;
+  }
+  [data-photo-picker-target="filmstrip"]::-webkit-scrollbar-thumb:hover,
+  [data-photo-picker-target="slideshowList"]::-webkit-scrollbar-thumb:hover {
+    background: rgba(255,255,255,0.5);
+  }
+
+  /* Filmstrip item hover zoom */
+  .filmstrip-item:hover {
+    transform: scale(1.15);
+    z-index: 10;
+  }
+
+  /* Slideshow card styling */
+  .slideshow-card {
+    scroll-snap-align: start;
   }
 </style>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,14 @@ Rails.application.routes.draw do
   end
 
   # Saved slideshows
-  resources :slideshows, only: [ :index, :show, :create, :edit, :update, :destroy ]
+  resources :slideshows, only: [ :index, :show, :create, :edit, :update, :destroy ] do
+    collection do
+      get :search
+    end
+    member do
+      post :add_uploads
+    end
+  end
 
   # External photo imports
   resources :imports, only: [ :index ] do

--- a/lib/tasks/variants.rake
+++ b/lib/tasks/variants.rake
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+namespace :variants do
+  desc "Generate missing image variants for all uploads"
+  task regenerate: :environment do
+    total = Upload.count
+    processed = 0
+    skipped = 0
+
+    puts "Processing #{total} uploads..."
+
+    Upload.find_each do |upload|
+      unless upload.file.attached?
+        skipped += 1
+        next
+      end
+
+      unless upload.file.content_type.start_with?("image/")
+        skipped += 1
+        next
+      end
+
+      ProcessMediaJob.perform_now(upload.id)
+      processed += 1
+
+      print "\rProcessed: #{processed}/#{total - skipped} (#{skipped} skipped)"
+    end
+
+    puts "\nDone! Processed #{processed} uploads, skipped #{skipped}."
+  end
+end

--- a/spec/requests/slideshows_spec.rb
+++ b/spec/requests/slideshows_spec.rb
@@ -1,0 +1,206 @@
+require 'rails_helper'
+
+RSpec.describe "Slideshows", type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:gallery) { create(:gallery, user: user) }
+  let!(:uploads) { create_list(:upload, 3, user: user, gallery: gallery) }
+
+  before { sign_in user }
+
+  describe "GET /slideshows" do
+    it "returns http success" do
+      get slideshows_path
+      expect(response).to have_http_status(:success)
+    end
+
+    it "shows user's slideshows" do
+      slideshow = create(:slideshow, user: user, title: "My Slideshow")
+      get slideshows_path
+      expect(response.body).to include("My Slideshow")
+    end
+  end
+
+  describe "POST /slideshows" do
+    it "creates a slideshow with uploads" do
+      expect {
+        post slideshows_path, params: {
+          slideshow: { title: "New Slideshow", description: "Test", interval: 5 },
+          upload_ids: uploads.map(&:id)
+        }, as: :json
+      }.to change(Slideshow, :count).by(1)
+
+      expect(response).to have_http_status(:success)
+      json = JSON.parse(response.body)
+      expect(json["id"]).to be_present
+
+      slideshow = Slideshow.last
+      expect(slideshow.title).to eq("New Slideshow")
+      expect(slideshow.uploads.count).to eq(3)
+    end
+
+    it "only includes uploads from user's galleries" do
+      other_gallery = create(:gallery, user: other_user)
+      other_upload = create(:upload, user: other_user, gallery: other_gallery)
+
+      post slideshows_path, params: {
+        slideshow: { title: "Test", description: "Test", interval: 5 },
+        upload_ids: [ uploads.first.id, other_upload.id ]
+      }, as: :json
+
+      slideshow = Slideshow.last
+      expect(slideshow.uploads.count).to eq(1)
+      expect(slideshow.uploads).not_to include(other_upload)
+    end
+
+    it "returns errors for invalid slideshow" do
+      post slideshows_path, params: {
+        slideshow: { title: "", description: "Test", interval: 5 }
+      }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+  end
+
+  describe "GET /slideshows/search" do
+    let!(:slideshow1) { create(:slideshow, user: user, title: "Summer Vacation") }
+    let!(:slideshow2) { create(:slideshow, user: user, title: "Winter Holiday") }
+    let!(:other_slideshow) { create(:slideshow, user: other_user, title: "Other User Slideshow") }
+
+    it "returns user's slideshows as JSON" do
+      get search_slideshows_path, as: :json
+
+      expect(response).to have_http_status(:success)
+      json = JSON.parse(response.body)
+      expect(json.length).to eq(2)
+      titles = json.map { |s| s["title"] }
+      expect(titles).to include("Summer Vacation", "Winter Holiday")
+      expect(titles).not_to include("Other User Slideshow")
+    end
+
+    it "filters slideshows by search query" do
+      get search_slideshows_path, params: { q: "Summer" }, as: :json
+
+      json = JSON.parse(response.body)
+      expect(json.length).to eq(1)
+      expect(json.first["title"]).to eq("Summer Vacation")
+    end
+
+    it "returns empty array when no matches" do
+      get search_slideshows_path, params: { q: "Nonexistent" }, as: :json
+
+      json = JSON.parse(response.body)
+      expect(json).to eq([])
+    end
+
+    it "includes slideshow metadata" do
+      slideshow1.uploads << uploads.first
+
+      get search_slideshows_path, as: :json
+
+      json = JSON.parse(response.body)
+      slideshow_data = json.find { |s| s["id"] == slideshow1.id }
+      expect(slideshow_data["photo_count"]).to eq(1)
+      expect(slideshow_data).to have_key("cover_url")
+    end
+  end
+
+  describe "POST /slideshows/:id/add_uploads" do
+    let!(:slideshow) { create(:slideshow, user: user, title: "My Slideshow") }
+
+    it "adds uploads to an existing slideshow" do
+      expect {
+        post add_uploads_slideshow_path(slideshow), params: {
+          upload_ids: uploads.map(&:id)
+        }, as: :json
+      }.to change { slideshow.uploads.count }.by(3)
+
+      expect(response).to have_http_status(:success)
+      json = JSON.parse(response.body)
+      expect(json["success"]).to be true
+      expect(json["added_count"]).to eq(3)
+      expect(json["total_count"]).to eq(3)
+    end
+
+    it "skips uploads already in slideshow" do
+      slideshow.uploads << uploads.first
+
+      post add_uploads_slideshow_path(slideshow), params: {
+        upload_ids: uploads.map(&:id)
+      }, as: :json
+
+      json = JSON.parse(response.body)
+      expect(json["added_count"]).to eq(2)
+      expect(json["total_count"]).to eq(3)
+    end
+
+    it "only adds uploads from user's galleries" do
+      other_gallery = create(:gallery, user: other_user)
+      other_upload = create(:upload, user: other_user, gallery: other_gallery)
+
+      post add_uploads_slideshow_path(slideshow), params: {
+        upload_ids: [ uploads.first.id, other_upload.id ]
+      }, as: :json
+
+      expect(slideshow.uploads.count).to eq(1)
+      expect(slideshow.uploads).not_to include(other_upload)
+    end
+
+    it "returns error when no photos selected" do
+      post add_uploads_slideshow_path(slideshow), params: {
+        upload_ids: []
+      }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_content)
+      json = JSON.parse(response.body)
+      expect(json["error"]).to eq("No photos selected")
+    end
+
+    it "prevents adding to other user's slideshow" do
+      other_slideshow = create(:slideshow, user: other_user)
+
+      post add_uploads_slideshow_path(other_slideshow), params: {
+        upload_ids: uploads.map(&:id)
+      }, as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "sets correct position for added uploads" do
+      post add_uploads_slideshow_path(slideshow), params: {
+        upload_ids: uploads.map(&:id)
+      }, as: :json
+
+      positions = slideshow.slideshow_uploads.order(:position).pluck(:position)
+      expect(positions).to eq([ 0, 1, 2 ])
+    end
+  end
+
+  describe "admin access" do
+    let(:admin) { create(:user, :admin) }
+
+    before { sign_in admin }
+
+    it "allows admin to search all slideshows" do
+      user_slideshow = create(:slideshow, user: user, title: "User Slideshow")
+
+      get search_slideshows_path, as: :json
+
+      json = JSON.parse(response.body)
+      # Admin only sees their own slideshows in search (for adding photos)
+      # This is intentional - admin creates their own slideshows
+      expect(json.map { |s| s["title"] }).not_to include("User Slideshow")
+    end
+
+    it "allows admin to add any uploads to their slideshow" do
+      admin_slideshow = create(:slideshow, user: admin)
+
+      post add_uploads_slideshow_path(admin_slideshow), params: {
+        upload_ids: uploads.map(&:id)
+      }, as: :json
+
+      expect(response).to have_http_status(:success)
+      expect(admin_slideshow.uploads.count).to eq(3)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add "Add to..." option in the gallery slideshow dropdown
- Full-screen photo picker modal with:
  - Search bar to filter existing slideshows
  - Horizontal scrollable slideshow cards with cover images
  - "Create New" card that opens centered modal form (title + description required)
  - Filmstrip of gallery photos with selection
  - Hover zoom on desktop, long-press preview on mobile
- New API endpoints:
  - `GET /slideshows/search` - search slideshows by title
  - `POST /slideshows/:id/add_uploads` - add photos to existing slideshow
- Rake task `rails variants:regenerate` for production variant generation

## Test plan
- [x] `bundle exec rspec` - 163 tests pass (17 new)
- [x] `bundle exec rubocop` - no offenses
- [x] `bundle exec brakeman` - no security warnings
- [x] Manual testing of photo picker UI
- [x] Test on mobile device