### PR TITLE
Add hierarchical timeline feature

### DIFF
--- a/app/controllers/timeline_controller.rb
+++ b/app/controllers/timeline_controller.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+class TimelineController < ApplicationController
+  before_action :authenticate_user!
+
+  SAMPLE_LIMIT = 10
+
+  def index
+    @decades = decades_with_samples
+  end
+
+  def decade
+    @decade_start = parse_decade(params[:decade])
+    @years = years_with_samples(@decade_start)
+  end
+
+  def year
+    @decade_start = parse_decade(params[:decade])
+    @year = params[:year].to_i
+    @months = months_with_samples(@year)
+  end
+
+  def month
+    @decade_start = parse_decade(params[:decade])
+    @year = params[:year].to_i
+    @month = params[:month].to_i
+    @uploads = month_uploads(@year, @month)
+  end
+
+  private
+
+  def base_scope
+    scope = Upload.where.not(date_taken: nil)
+    scope = scope.where(user_id: current_user.id) unless current_user.admin?
+    scope
+  end
+
+  def parse_decade(decade_param)
+    decade_param.to_s.gsub(/s$/, "").to_i
+  end
+
+  def decades_with_samples
+    # Query to get decade groupings with counts and sample IDs
+    # Note: GROUP BY must use position (1) since PostgreSQL doesn't allow alias in GROUP BY
+    results = base_scope
+      .select(
+        "FLOOR(EXTRACT(YEAR FROM date_taken) / 10) * 10 AS decade_start",
+        "COUNT(*) AS photo_count",
+        "(ARRAY_AGG(uploads.id ORDER BY date_taken DESC))[1:#{SAMPLE_LIMIT}] AS upload_ids"
+      )
+      .group(Arel.sql("1"))
+      .order(Arel.sql("1 DESC"))
+
+    build_grouped_data(results, :decade_start)
+  end
+
+  def years_with_samples(decade_start)
+    decade_end = decade_start + 9
+    results = base_scope
+      .where("EXTRACT(YEAR FROM date_taken) BETWEEN ? AND ?", decade_start, decade_end)
+      .select(
+        "EXTRACT(YEAR FROM date_taken)::integer AS year_value",
+        "COUNT(*) AS photo_count",
+        "(ARRAY_AGG(uploads.id ORDER BY date_taken DESC))[1:#{SAMPLE_LIMIT}] AS upload_ids"
+      )
+      .group(Arel.sql("1"))
+      .order(Arel.sql("1 DESC"))
+
+    build_grouped_data(results, :year_value)
+  end
+
+  def months_with_samples(year)
+    results = base_scope
+      .where("EXTRACT(YEAR FROM date_taken) = ?", year)
+      .select(
+        "EXTRACT(MONTH FROM date_taken)::integer AS month_value",
+        "COUNT(*) AS photo_count",
+        "(ARRAY_AGG(uploads.id ORDER BY date_taken DESC))[1:#{SAMPLE_LIMIT}] AS upload_ids"
+      )
+      .group(Arel.sql("1"))
+      .order(Arel.sql("1 DESC"))
+
+    build_grouped_data(results, :month_value)
+  end
+
+  def month_uploads(year, month)
+    base_scope
+      .where("EXTRACT(YEAR FROM date_taken) = ? AND EXTRACT(MONTH FROM date_taken) = ?", year, month)
+      .includes(file_attachment: :blob)
+      .order(date_taken: :desc)
+  end
+
+  def build_grouped_data(results, key_field)
+    return [] if results.empty?
+
+    # Collect all sample IDs for batch loading
+    all_sample_ids = results.flat_map { |r| parse_pg_array(r.upload_ids) }
+
+    # Batch load all samples with eager-loaded attachments
+    samples_by_id = Upload
+      .where(id: all_sample_ids)
+      .includes(file_attachment: :blob)
+      .index_by(&:id)
+
+    results.map do |result|
+      sample_ids = parse_pg_array(result.upload_ids)
+      samples = sample_ids.map { |id| samples_by_id[id] }.compact
+
+      {
+        key: result.send(key_field).to_i,
+        count: result.photo_count,
+        samples: samples,
+        overflow: [ result.photo_count - samples.size, 0 ].max
+      }
+    end
+  end
+
+  def parse_pg_array(pg_array)
+    return [] if pg_array.blank?
+
+    # Handle both string representation and actual array
+    if pg_array.is_a?(String)
+      pg_array.gsub(/[{}]/, "").split(",").map(&:to_i)
+    else
+      pg_array.map(&:to_i)
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -62,6 +62,9 @@
                   </svg>
                 </button>
                 <div data-dropdown-target="menu" class="hidden absolute right-0 mt-2 w-48 bg-neutral-800 rounded-lg shadow-xl border border-white/10 py-1">
+                  <%= link_to timeline_path, class: "block px-4 py-2 text-sm text-white/70 hover:text-white hover:bg-white/5 transition-colors" do %>
+                    Timeline
+                  <% end %>
                   <%= link_to slideshows_path, class: "block px-4 py-2 text-sm text-white/70 hover:text-white hover:bg-white/5 transition-colors" do %>
                     My Slideshows
                   <% end %>

--- a/app/views/timeline/_breadcrumbs.html.erb
+++ b/app/views/timeline/_breadcrumbs.html.erb
@@ -1,0 +1,34 @@
+<nav class="flex items-center gap-2 text-sm text-neutral-500 mb-6">
+  <%= link_to timeline_path, class: "hover:text-neutral-800 transition-colors" do %>
+    Timeline
+  <% end %>
+
+  <% if local_assigns[:decade_start] %>
+    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+    </svg>
+    <% if local_assigns[:year] %>
+      <%= link_to "#{decade_start}s", timeline_decade_path(decade: "#{decade_start}s"), class: "hover:text-neutral-800 transition-colors" %>
+    <% else %>
+      <span class="text-neutral-800"><%= decade_start %>s</span>
+    <% end %>
+  <% end %>
+
+  <% if local_assigns[:year] %>
+    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+    </svg>
+    <% if local_assigns[:month] %>
+      <%= link_to year, timeline_year_path(decade: "#{decade_start}s", year: year), class: "hover:text-neutral-800 transition-colors" %>
+    <% else %>
+      <span class="text-neutral-800"><%= year %></span>
+    <% end %>
+  <% end %>
+
+  <% if local_assigns[:month] %>
+    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+    </svg>
+    <span class="text-neutral-800"><%= Date::MONTHNAMES[month] %></span>
+  <% end %>
+</nav>

--- a/app/views/timeline/_lightbox_modal.html.erb
+++ b/app/views/timeline/_lightbox_modal.html.erb
@@ -1,0 +1,55 @@
+<!-- Lightbox Modal -->
+<div data-search-lightbox-target="modal"
+     data-action="click->search-lightbox#close"
+     class="hidden fixed inset-0 z-50 bg-black">
+
+  <!-- Top bar -->
+  <div class="absolute top-0 left-0 right-0 p-4 flex items-center justify-between z-20" data-action="click->search-lightbox#stopPropagation">
+    <button data-action="click->search-lightbox#close" class="p-2 text-white/70 hover:text-white transition-colors rounded-lg hover:bg-white/10">
+      <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+      </svg>
+    </button>
+
+    <span data-search-lightbox-target="counter" class="text-white/70 text-sm"></span>
+
+    <div class="flex items-center gap-2">
+      <a href="#" data-search-lightbox-target="galleryLink" class="inline-flex items-center gap-2 px-3 py-1.5 text-sm text-white/70 hover:text-white hover:bg-white/10 rounded-lg transition-colors">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+        </svg>
+        <span data-search-lightbox-target="galleryTitle">View in Gallery</span>
+      </a>
+    </div>
+  </div>
+
+  <!-- Image area -->
+  <div class="absolute inset-0 flex items-center justify-center pt-16 pb-24" data-action="click->search-lightbox#stopPropagation">
+    <button data-search-lightbox-target="prevBtn" data-action="click->search-lightbox#prev" class="absolute left-4 top-1/2 -translate-y-1/2 p-3 text-white/50 hover:text-white hover:bg-white/10 rounded-full transition-colors z-10">
+      <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
+      </svg>
+    </button>
+
+    <img data-search-lightbox-target="image" src="" alt="" class="max-w-[90vw] max-h-full object-contain">
+
+    <button data-search-lightbox-target="nextBtn" data-action="click->search-lightbox#next" class="absolute right-4 top-1/2 -translate-y-1/2 p-3 text-white/50 hover:text-white hover:bg-white/10 rounded-full transition-colors z-10">
+      <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+      </svg>
+    </button>
+  </div>
+
+  <!-- Bottom info bar -->
+  <div class="absolute bottom-0 left-0 right-0 z-20" data-action="click->search-lightbox#stopPropagation">
+    <div class="bg-neutral-900 border-t border-white/10 px-6 py-4">
+      <div class="max-w-3xl mx-auto">
+        <div class="flex items-center justify-between mb-1">
+          <h3 data-search-lightbox-target="title" class="text-white text-lg font-medium"></h3>
+          <span data-search-lightbox-target="dateTaken" class="text-white/50 text-sm"></span>
+        </div>
+        <p data-search-lightbox-target="caption" class="text-white/70 text-sm"></p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/timeline/_row.html.erb
+++ b/app/views/timeline/_row.html.erb
@@ -1,0 +1,69 @@
+<%
+  # Expected locals: title, subtitle, count, drill_path, samples, overflow
+  images_data = samples.select { |u| u.file.attached? }.map.with_index do |u, i|
+    {
+      id: u.id,
+      index: i,
+      title: u.title,
+      caption: u.caption,
+      date_taken: u.date_taken&.to_s,
+      gallery_title: u.gallery.title,
+      gallery_path: gallery_path(u.gallery, anchor: dom_id(u)),
+      original: url_for(u.file),
+      thumb: upload_variant_url(u, :thumb),
+      medium: upload_variant_url(u, :medium),
+      large: upload_variant_url(u, :large),
+      thumb_webp: upload_variant_url(u, :thumb, format: :webp),
+      medium_webp: upload_variant_url(u, :medium, format: :webp),
+      large_webp: upload_variant_url(u, :large, format: :webp)
+    }
+  end
+%>
+
+<div class="bg-white rounded-xl shadow-sm overflow-hidden"
+     data-controller="search-lightbox"
+     data-search-lightbox-images-value="<%= images_data.to_json %>"
+     data-action="keydown@window->search-lightbox#keydown">
+
+  <div class="flex items-center gap-4 p-4">
+    <!-- Header: clickable to drill down -->
+    <%= link_to drill_path, class: "flex-shrink-0 flex items-center gap-3 group" do %>
+      <div>
+        <h2 class="text-lg font-semibold text-neutral-800 group-hover:text-blue-600 transition-colors">
+          <%= title %>
+        </h2>
+        <p class="text-sm text-neutral-500">
+          <%= pluralize(count, 'photo') %>
+        </p>
+      </div>
+      <svg class="w-5 h-5 text-neutral-400 group-hover:text-blue-600 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+      </svg>
+    <% end %>
+
+    <!-- Thumbnails: each opens lightbox -->
+    <div class="flex-1 flex items-center gap-2 overflow-hidden">
+      <% samples.each_with_index do |upload, i| %>
+        <% next unless upload.file.attached? %>
+        <a href="#"
+           data-action="click->search-lightbox#open"
+           data-index="<%= i %>"
+           class="flex-shrink-0 w-16 h-16 sm:w-20 sm:h-20 rounded-lg overflow-hidden bg-neutral-100 hover:ring-2 hover:ring-blue-500 transition-all">
+          <%= upload_picture_tag upload, :thumb,
+              class: "w-full h-full object-cover",
+              loading: "lazy",
+              alt: upload.title %>
+        </a>
+      <% end %>
+
+      <% if overflow > 0 %>
+        <%= link_to drill_path, class: "flex-shrink-0 w-16 h-16 sm:w-20 sm:h-20 rounded-lg bg-neutral-100 hover:bg-neutral-200 flex items-center justify-center text-neutral-600 font-medium transition-colors" do %>
+          +<%= overflow %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+
+  <!-- Lightbox modal (per-row) -->
+  <%= render "timeline/lightbox_modal" %>
+</div>

--- a/app/views/timeline/decade.html.erb
+++ b/app/views/timeline/decade.html.erb
@@ -1,0 +1,32 @@
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+  <%= render "timeline/breadcrumbs", decade_start: @decade_start %>
+
+  <div class="mb-8">
+    <h1 class="text-2xl font-semibold text-neutral-800 mb-2">The <%= @decade_start %>s</h1>
+    <p class="text-neutral-500 text-sm">Browse photos by year</p>
+  </div>
+
+  <% if @years.any? %>
+    <div class="space-y-4">
+      <% @years.each do |year| %>
+        <%= render "timeline/row",
+            title: year[:key].to_s,
+            subtitle: nil,
+            count: year[:count],
+            drill_path: timeline_year_path(decade: "#{@decade_start}s", year: year[:key]),
+            samples: year[:samples],
+            overflow: year[:overflow] %>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="text-center py-20">
+      <div class="inline-flex items-center justify-center w-16 h-16 bg-neutral-100 rounded-full mb-4">
+        <svg class="w-8 h-8 text-neutral-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+        </svg>
+      </div>
+      <h3 class="text-lg font-medium text-neutral-800 mb-2">No photos in the <%= @decade_start %>s</h3>
+      <p class="text-neutral-500 text-sm">Photos from this decade will appear here</p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/timeline/index.html.erb
+++ b/app/views/timeline/index.html.erb
@@ -1,0 +1,39 @@
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+  <div class="mb-6">
+    <%= link_to galleries_path, class: "inline-flex items-center text-sm text-neutral-500 hover:text-neutral-800 transition-colors" do %>
+      <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
+      </svg>
+      Back
+    <% end %>
+  </div>
+
+  <div class="mb-8">
+    <h1 class="text-2xl font-semibold text-neutral-800 mb-2">Timeline</h1>
+    <p class="text-neutral-500 text-sm">Browse photos by decade</p>
+  </div>
+
+  <% if @decades.any? %>
+    <div class="space-y-4">
+      <% @decades.each do |decade| %>
+        <%= render "timeline/row",
+            title: "#{decade[:key]}s",
+            subtitle: nil,
+            count: decade[:count],
+            drill_path: timeline_decade_path(decade: "#{decade[:key]}s"),
+            samples: decade[:samples],
+            overflow: decade[:overflow] %>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="text-center py-20">
+      <div class="inline-flex items-center justify-center w-16 h-16 bg-neutral-100 rounded-full mb-4">
+        <svg class="w-8 h-8 text-neutral-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+        </svg>
+      </div>
+      <h3 class="text-lg font-medium text-neutral-800 mb-2">No dated photos</h3>
+      <p class="text-neutral-500 text-sm">Photos with dates will appear here organised by decade</p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/timeline/month.html.erb
+++ b/app/views/timeline/month.html.erb
@@ -1,0 +1,75 @@
+<%
+  images_data = @uploads.to_a.select { |u| u.file.attached? }.map.with_index do |u, i|
+    {
+      id: u.id,
+      index: i,
+      title: u.title,
+      caption: u.caption,
+      date_taken: u.date_taken&.to_s,
+      gallery_title: u.gallery.title,
+      gallery_path: gallery_path(u.gallery, anchor: dom_id(u)),
+      original: url_for(u.file),
+      thumb: upload_variant_url(u, :thumb),
+      medium: upload_variant_url(u, :medium),
+      large: upload_variant_url(u, :large),
+      thumb_webp: upload_variant_url(u, :thumb, format: :webp),
+      medium_webp: upload_variant_url(u, :medium, format: :webp),
+      large_webp: upload_variant_url(u, :large, format: :webp)
+    }
+  end
+%>
+
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8"
+     data-controller="search-lightbox"
+     data-search-lightbox-images-value="<%= images_data.to_json %>"
+     data-action="keydown@window->search-lightbox#keydown">
+
+  <%= render "timeline/breadcrumbs", decade_start: @decade_start, year: @year, month: @month %>
+
+  <div class="mb-8">
+    <h1 class="text-2xl font-semibold text-neutral-800 mb-2">
+      <%= Date::MONTHNAMES[@month] %> <%= @year %>
+    </h1>
+    <p class="text-neutral-500 text-sm"><%= pluralize(@uploads.size, 'photo') %></p>
+  </div>
+
+  <% if @uploads.any? %>
+    <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+      <% @uploads.each_with_index do |upload, index| %>
+        <% next unless upload.file.attached? %>
+        <a href="#" data-action="click->search-lightbox#open" data-index="<%= index %>" class="group block">
+          <div class="relative aspect-square bg-neutral-100 rounded-xl overflow-hidden shadow-sm hover:shadow-lg hover:-translate-y-0.5 transition-all duration-200">
+            <%= upload_picture_tag upload, :thumb,
+                class: "w-full h-full object-cover group-hover:scale-105 transition-transform duration-300",
+                loading: "lazy",
+                alt: upload.title %>
+            <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/0 to-black/0 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+              <div class="absolute bottom-0 left-0 right-0 p-3">
+                <% if upload.title.present? %>
+                  <p class="text-white text-sm font-medium mb-1 line-clamp-1"><%= upload.title %></p>
+                <% end %>
+                <p class="text-white/70 text-xs"><%= upload.gallery.title %></p>
+                <% if upload.date_taken.present? %>
+                  <p class="text-white/50 text-xs"><%= upload.date_taken.strftime("%d %b %Y") %></p>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        </a>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="text-center py-20">
+      <div class="inline-flex items-center justify-center w-16 h-16 bg-neutral-100 rounded-full mb-4">
+        <svg class="w-8 h-8 text-neutral-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+        </svg>
+      </div>
+      <h3 class="text-lg font-medium text-neutral-800 mb-2">No photos in <%= Date::MONTHNAMES[@month] %> <%= @year %></h3>
+      <p class="text-neutral-500 text-sm">Photos from this month will appear here</p>
+    </div>
+  <% end %>
+
+  <!-- Lightbox modal -->
+  <%= render "timeline/lightbox_modal" %>
+</div>

--- a/app/views/timeline/year.html.erb
+++ b/app/views/timeline/year.html.erb
@@ -1,0 +1,32 @@
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+  <%= render "timeline/breadcrumbs", decade_start: @decade_start, year: @year %>
+
+  <div class="mb-8">
+    <h1 class="text-2xl font-semibold text-neutral-800 mb-2"><%= @year %></h1>
+    <p class="text-neutral-500 text-sm">Browse photos by month</p>
+  </div>
+
+  <% if @months.any? %>
+    <div class="space-y-4">
+      <% @months.each do |month| %>
+        <%= render "timeline/row",
+            title: Date::MONTHNAMES[month[:key]],
+            subtitle: nil,
+            count: month[:count],
+            drill_path: timeline_month_path(decade: "#{@decade_start}s", year: @year, month: month[:key]),
+            samples: month[:samples],
+            overflow: month[:overflow] %>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="text-center py-20">
+      <div class="inline-flex items-center justify-center w-16 h-16 bg-neutral-100 rounded-full mb-4">
+        <svg class="w-8 h-8 text-neutral-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+        </svg>
+      </div>
+      <h3 class="text-lg font-medium text-neutral-800 mb-2">No photos in <%= @year %></h3>
+      <p class="text-neutral-500 text-sm">Photos from this year will appear here</p>
+    </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,15 @@ Rails.application.routes.draw do
   # Search
   get "search", to: "search#index"
 
+  # Timeline - hierarchical date-based photo browser
+  get "timeline", to: "timeline#index", as: :timeline
+  get "timeline/:decade", to: "timeline#decade", as: :timeline_decade,
+      constraints: { decade: /\d{4}s/ }
+  get "timeline/:decade/:year", to: "timeline#year", as: :timeline_year,
+      constraints: { decade: /\d{4}s/, year: /\d{4}/ }
+  get "timeline/:decade/:year/:month", to: "timeline#month", as: :timeline_month,
+      constraints: { decade: /\d{4}s/, year: /\d{4}/, month: /\d{1,2}/ }
+
   # Spotify search API
   get "spotify/search", to: "spotify#search"
 

--- a/spec/requests/timeline_spec.rb
+++ b/spec/requests/timeline_spec.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Timeline", type: :request do
+  let(:user) { create(:user) }
+  let(:admin) { create(:user, role: :admin) }
+  let(:gallery) { create(:gallery, user: user) }
+
+  describe "GET /timeline" do
+    context "when not signed in" do
+      it "redirects to sign in" do
+        get timeline_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when signed in" do
+      before { sign_in user }
+
+      it "returns success" do
+        get timeline_path
+        expect(response).to have_http_status(:success)
+      end
+
+      it "groups photos by decade" do
+        create(:upload, gallery: gallery, user: user, date_taken: Date.new(1978, 6, 15))
+        create(:upload, gallery: gallery, user: user, date_taken: Date.new(1998, 3, 20))
+
+        get timeline_path
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include("1970s")
+        expect(response.body).to include("1990s")
+      end
+
+      it "skips uploads without date_taken" do
+        create(:upload, gallery: gallery, user: user, date_taken: nil)
+
+        get timeline_path
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include("No dated photos")
+      end
+
+      it "only shows current user's photos" do
+        other_user = create(:user)
+        other_gallery = create(:gallery, user: other_user)
+        create(:upload, gallery: other_gallery, user: other_user, date_taken: Date.new(1985, 5, 10))
+
+        get timeline_path
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include("No dated photos")
+      end
+    end
+
+    context "when signed in as admin" do
+      before { sign_in admin }
+
+      it "shows all users' photos" do
+        create(:upload, gallery: gallery, user: user, date_taken: Date.new(1978, 6, 15))
+
+        get timeline_path
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include("1970s")
+      end
+    end
+  end
+
+  describe "GET /timeline/:decade" do
+    before { sign_in user }
+
+    it "returns success" do
+      create(:upload, gallery: gallery, user: user, date_taken: Date.new(1978, 6, 15))
+
+      get timeline_decade_path(decade: "1970s")
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it "shows years within the decade" do
+      create(:upload, gallery: gallery, user: user, date_taken: Date.new(1975, 3, 10))
+      create(:upload, gallery: gallery, user: user, date_taken: Date.new(1978, 6, 15))
+
+      get timeline_decade_path(decade: "1970s")
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("1975")
+      expect(response.body).to include("1978")
+    end
+
+    it "includes breadcrumbs" do
+      create(:upload, gallery: gallery, user: user, date_taken: Date.new(1978, 6, 15))
+
+      get timeline_decade_path(decade: "1970s")
+
+      expect(response.body).to include("Timeline")
+      expect(response.body).to include("1970s")
+    end
+
+    it "shows empty state when no photos in decade" do
+      get timeline_decade_path(decade: "2010s")
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("No photos in the 2010s")
+    end
+  end
+
+  describe "GET /timeline/:decade/:year" do
+    before { sign_in user }
+
+    it "returns success" do
+      create(:upload, gallery: gallery, user: user, date_taken: Date.new(1978, 6, 15))
+
+      get timeline_year_path(decade: "1970s", year: "1978")
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it "shows months within the year" do
+      create(:upload, gallery: gallery, user: user, date_taken: Date.new(1978, 3, 10))
+      create(:upload, gallery: gallery, user: user, date_taken: Date.new(1978, 6, 15))
+
+      get timeline_year_path(decade: "1970s", year: "1978")
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("March")
+      expect(response.body).to include("June")
+    end
+
+    it "includes breadcrumbs with links" do
+      create(:upload, gallery: gallery, user: user, date_taken: Date.new(1978, 6, 15))
+
+      get timeline_year_path(decade: "1970s", year: "1978")
+
+      expect(response.body).to include("Timeline")
+      expect(response.body).to include("1970s")
+      expect(response.body).to include("1978")
+    end
+  end
+
+  describe "GET /timeline/:decade/:year/:month" do
+    before { sign_in user }
+
+    it "returns success" do
+      create(:upload, gallery: gallery, user: user, date_taken: Date.new(1978, 6, 15))
+
+      get timeline_month_path(decade: "1970s", year: "1978", month: "6")
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it "shows all photos from the month" do
+      upload1 = create(:upload, gallery: gallery, user: user, title: "Photo One", date_taken: Date.new(1978, 6, 10))
+      upload2 = create(:upload, gallery: gallery, user: user, title: "Photo Two", date_taken: Date.new(1978, 6, 20))
+
+      get timeline_month_path(decade: "1970s", year: "1978", month: "6")
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("2 photos")
+    end
+
+    it "includes full breadcrumb navigation" do
+      create(:upload, gallery: gallery, user: user, date_taken: Date.new(1978, 6, 15))
+
+      get timeline_month_path(decade: "1970s", year: "1978", month: "6")
+
+      expect(response.body).to include("Timeline")
+      expect(response.body).to include("1970s")
+      expect(response.body).to include("1978")
+      expect(response.body).to include("June")
+    end
+
+    it "shows photo grid" do
+      create(:upload, gallery: gallery, user: user, date_taken: Date.new(1978, 6, 15))
+
+      get timeline_month_path(decade: "1970s", year: "1978", month: "6")
+
+      expect(response.body).to include("data-controller=\"search-lightbox\"")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add timeline feature for browsing photos by decade, year, and month
- Hierarchical navigation: Decades -> Years -> Months -> Photo grid
- Thumbnail previews with lightbox integration
- Breadcrumb navigation at all levels

## Changes
- **Routes**: `/timeline`, `/timeline/:decade`, `/timeline/:decade/:year`, `/timeline/:decade/:year/:month`
- **Controller**: Efficient PostgreSQL queries using `ARRAY_AGG` for sample thumbnails
- **Views**: Index, decade, year, month views with reusable row and lightbox partials
- **Navigation**: Timeline link added to user dropdown menu
- **Authorization**: Non-admin users only see their own photos

## Test plan
- [x] All 163 tests pass
- [x] Rubocop: no offenses
- [x] Brakeman: no security warnings
- [ ] Manual test: visit `/timeline`, click through hierarchy
- [ ] Mobile test: verify thumbnail overflow and +N counts
- [ ] Lightbox test: click thumbnail -> opens lightbox with correct image