### PR TITLE
Add UI to manage photos in slideshows

### DIFF
--- a/app/controllers/slideshows_controller.rb
+++ b/app/controllers/slideshows_controller.rb
@@ -67,7 +67,17 @@ class SlideshowsController < ApplicationController
   end
 
   def edit
-    @slideshow = current_user.slideshows.find(params[:id])
+    @slideshow = if current_user.admin?
+      Slideshow.find(params[:id])
+    else
+      current_user.slideshows.find(params[:id])
+    end
+    @slideshow_uploads = @slideshow.slideshow_uploads.includes(upload: { file_attachment: :blob })
+    @galleries = if current_user.admin?
+      Gallery.includes(uploads: { file_attachment: :blob }).order(:title)
+    else
+      current_user.galleries.includes(uploads: { file_attachment: :blob }).order(:title)
+    end
   end
 
   def update
@@ -104,8 +114,50 @@ class SlideshowsController < ApplicationController
     }
   end
 
+  def remove_upload
+    @slideshow = if current_user.admin?
+      Slideshow.find(params[:id])
+    else
+      current_user.slideshows.find(params[:id])
+    end
+
+    slideshow_upload = @slideshow.slideshow_uploads.find_by(upload_id: params[:upload_id])
+
+    if slideshow_upload&.destroy
+      respond_to do |format|
+        format.html { redirect_to edit_slideshow_path(@slideshow), notice: "Photo removed from slideshow" }
+        format.json { render json: { success: true, total_count: @slideshow.uploads.count } }
+      end
+    else
+      respond_to do |format|
+        format.html { redirect_to edit_slideshow_path(@slideshow), alert: "Could not remove photo" }
+        format.json { render json: { error: "Could not remove photo" }, status: :unprocessable_content }
+      end
+    end
+  end
+
+  def reorder_uploads
+    @slideshow = if current_user.admin?
+      Slideshow.find(params[:id])
+    else
+      current_user.slideshows.find(params[:id])
+    end
+
+    upload_ids = params[:upload_ids] || []
+
+    upload_ids.each_with_index do |upload_id, index|
+      @slideshow.slideshow_uploads.where(upload_id: upload_id).update_all(position: index)
+    end
+
+    render json: { success: true }
+  end
+
   def add_uploads
-    @slideshow = current_user.slideshows.find(params[:id])
+    @slideshow = if current_user.admin?
+      Slideshow.find(params[:id])
+    else
+      current_user.slideshows.find(params[:id])
+    end
 
     upload_ids = params[:upload_ids] || []
     return render json: { error: "No photos selected" }, status: :unprocessable_content if upload_ids.empty?

--- a/app/javascript/controllers/slideshow_editor_controller.js
+++ b/app/javascript/controllers/slideshow_editor_controller.js
@@ -1,0 +1,133 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["photoGrid", "photoCount", "emptyState"]
+  static values = {
+    slideshowId: Number,
+    addUrl: String,
+    removeUrl: String,
+    reorderUrl: String
+  }
+
+  connect() {
+    this.selectedPhotos = new Set()
+  }
+
+  async removePhoto(event) {
+    const button = event.currentTarget
+    const uploadId = button.dataset.uploadId
+
+    if (!confirm("Remove this photo from the slideshow?")) {
+      return
+    }
+
+    try {
+      const response = await fetch(`${this.removeUrlValue}?upload_id=${uploadId}`, {
+        method: "DELETE",
+        headers: {
+          "X-CSRF-Token": document.querySelector('[name="csrf-token"]').content,
+          "Accept": "application/json"
+        }
+      })
+
+      if (response.ok) {
+        const data = await response.json()
+
+        // Remove the photo from the grid
+        const photoElement = button.closest("[data-upload-id]")
+        photoElement.remove()
+
+        // Update the count
+        this.updatePhotoCount(data.total_count)
+
+        // Update the "Added" badge in gallery picker
+        this.updateGalleryPickerState(uploadId, false)
+
+        // Show empty state if no photos left
+        if (data.total_count === 0 && this.hasEmptyStateTarget) {
+          this.photoGridTarget.innerHTML = ""
+          this.emptyStateTarget.classList.remove("hidden")
+        }
+      } else {
+        alert("Failed to remove photo. Please try again.")
+      }
+    } catch (error) {
+      console.error("Error removing photo:", error)
+      alert("Failed to remove photo. Please try again.")
+    }
+  }
+
+  async togglePhoto(event) {
+    const checkbox = event.currentTarget
+    const uploadId = checkbox.dataset.uploadId
+    const isChecked = checkbox.checked
+
+    if (isChecked) {
+      await this.addPhoto(uploadId, checkbox)
+    }
+  }
+
+  async addPhoto(uploadId, checkbox) {
+    try {
+      const response = await fetch(this.addUrlValue, {
+        method: "POST",
+        headers: {
+          "X-CSRF-Token": document.querySelector('[name="csrf-token"]').content,
+          "Content-Type": "application/json",
+          "Accept": "application/json"
+        },
+        body: JSON.stringify({ upload_ids: [uploadId] })
+      })
+
+      if (response.ok) {
+        const data = await response.json()
+
+        // Update the count
+        this.updatePhotoCount(data.total_count)
+
+        // Reload to show the new photo in the grid
+        // (A more sophisticated approach would dynamically add it)
+        window.location.reload()
+      } else {
+        checkbox.checked = false
+        alert("Failed to add photo. Please try again.")
+      }
+    } catch (error) {
+      console.error("Error adding photo:", error)
+      checkbox.checked = false
+      alert("Failed to add photo. Please try again.")
+    }
+  }
+
+  updatePhotoCount(count) {
+    if (this.hasPhotoCountTarget) {
+      this.photoCountTarget.textContent = `(${count})`
+    }
+  }
+
+  updateGalleryPickerState(uploadId, isAdded) {
+    // Find the checkbox in the gallery picker and update its state
+    const checkbox = this.element.querySelector(`input[data-upload-id="${uploadId}"]`)
+    if (checkbox) {
+      checkbox.checked = isAdded
+      checkbox.disabled = isAdded
+
+      const container = checkbox.closest(".relative")
+      const label = checkbox.closest("label")
+      const badge = container.querySelector(".bg-green-500")
+
+      if (isAdded) {
+        label.classList.add("opacity-50")
+        if (!badge) {
+          const newBadge = document.createElement("div")
+          newBadge.className = "absolute top-1 right-1 bg-green-500 text-white text-xs px-1.5 py-0.5 rounded"
+          newBadge.textContent = "Added"
+          container.appendChild(newBadge)
+        }
+      } else {
+        label.classList.remove("opacity-50")
+        if (badge) badge.remove()
+      }
+    }
+  }
+}

--- a/app/views/slideshows/edit.html.erb
+++ b/app/views/slideshows/edit.html.erb
@@ -1,4 +1,9 @@
-<div class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8"
+     data-controller="slideshow-editor"
+     data-slideshow-editor-slideshow-id-value="<%= @slideshow.id %>"
+     data-slideshow-editor-add-url-value="<%= add_uploads_slideshow_path(@slideshow) %>"
+     data-slideshow-editor-remove-url-value="<%= remove_upload_slideshow_path(@slideshow) %>"
+     data-slideshow-editor-reorder-url-value="<%= reorder_uploads_slideshow_path(@slideshow) %>">
   <div class="mb-6">
     <%= link_to slideshows_path, class: "inline-flex items-center gap-1 text-sm text-neutral-500 hover:text-neutral-700" do %>
       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -8,49 +13,171 @@
     <% end %>
   </div>
 
-  <div class="bg-white rounded-xl border border-neutral-200 shadow-sm p-6">
-    <h1 class="text-xl font-semibold text-neutral-800 mb-6">Edit Slideshow</h1>
+  <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+    <!-- Settings Panel -->
+    <div class="lg:col-span-1">
+      <div class="bg-white rounded-xl border border-neutral-200 shadow-sm p-6">
+        <h1 class="text-xl font-semibold text-neutral-800 mb-6">Edit Slideshow</h1>
 
-    <%= form_with model: @slideshow, local: true, class: "space-y-6" do |f| %>
-      <div>
-        <%= f.label :title, class: "block text-sm font-medium text-neutral-700 mb-1" %>
-        <%= f.text_field :title, class: "w-full px-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500" %>
-      </div>
+        <%= form_with model: @slideshow, local: true, class: "space-y-6" do |f| %>
+          <div>
+            <%= f.label :title, class: "block text-sm font-medium text-neutral-700 mb-1" %>
+            <%= f.text_field :title, class: "w-full px-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500" %>
+          </div>
 
-      <div>
-        <%= f.label :description, class: "block text-sm font-medium text-neutral-700 mb-1" %>
-        <%= f.text_area :description, rows: 3, class: "w-full px-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500" %>
-      </div>
+          <div>
+            <%= f.label :description, class: "block text-sm font-medium text-neutral-700 mb-1" %>
+            <%= f.text_area :description, rows: 3, class: "w-full px-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500" %>
+          </div>
 
-      <div>
-        <%= f.label :interval, "Interval (seconds)", class: "block text-sm font-medium text-neutral-700 mb-1" %>
-        <%= f.number_field :interval, min: 1, max: 60, class: "w-24 px-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500" %>
-      </div>
+          <div>
+            <%= f.label :interval, "Interval (seconds)", class: "block text-sm font-medium text-neutral-700 mb-1" %>
+            <%= f.number_field :interval, min: 1, max: 60, class: "w-24 px-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500" %>
+          </div>
 
-      <div>
-        <%= f.label :audio, "Background Music", class: "block text-sm font-medium text-neutral-700 mb-1" %>
-        <p class="text-sm text-neutral-500 mb-2">Upload an MP3 or M4A file to play during the slideshow.</p>
+          <div>
+            <%= f.label :audio, "Background Music", class: "block text-sm font-medium text-neutral-700 mb-1" %>
+            <p class="text-sm text-neutral-500 mb-2">Upload an MP3 or M4A file to play during the slideshow.</p>
 
-        <% if @slideshow.audio.attached? %>
-          <div class="flex items-center gap-3 p-3 bg-neutral-50 rounded-lg mb-3">
-            <svg class="w-8 h-8 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3"></path>
-            </svg>
-            <div class="flex-1">
-              <p class="text-sm font-medium text-neutral-800"><%= @slideshow.audio.filename %></p>
-              <p class="text-xs text-neutral-500"><%= number_to_human_size(@slideshow.audio.byte_size) %></p>
-            </div>
-            <%= button_to "Remove", slideshow_path(@slideshow, slideshow: { audio: nil }), method: :patch, class: "text-sm text-red-600 hover:text-red-700", data: { turbo_confirm: "Remove audio?" } %>
+            <% if @slideshow.audio.attached? %>
+              <div class="flex items-center gap-3 p-3 bg-neutral-50 rounded-lg mb-3">
+                <svg class="w-8 h-8 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3"></path>
+                </svg>
+                <div class="flex-1">
+                  <p class="text-sm font-medium text-neutral-800"><%= @slideshow.audio.filename %></p>
+                  <p class="text-xs text-neutral-500"><%= number_to_human_size(@slideshow.audio.byte_size) %></p>
+                </div>
+                <%= button_to "Remove", slideshow_path(@slideshow, slideshow: { audio: nil }), method: :patch, class: "text-sm text-red-600 hover:text-red-700", data: { turbo_confirm: "Remove audio?" } %>
+              </div>
+            <% end %>
+
+            <%= f.file_field :audio, accept: "audio/*", class: "block w-full text-sm text-neutral-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100" %>
+          </div>
+
+          <div class="flex items-center gap-3 pt-4">
+            <%= f.submit "Save Changes", class: "px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition-colors cursor-pointer" %>
+            <%= link_to "Cancel", slideshow_path(@slideshow), class: "px-4 py-2 text-neutral-600 hover:text-neutral-800 text-sm" %>
           </div>
         <% end %>
+      </div>
+    </div>
 
-        <%= f.file_field :audio, accept: "audio/*", class: "block w-full text-sm text-neutral-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100" %>
+    <!-- Photos Panel -->
+    <div class="lg:col-span-2 space-y-6">
+      <!-- Current Photos -->
+      <div class="bg-white rounded-xl border border-neutral-200 shadow-sm p-6">
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-lg font-semibold text-neutral-800">
+            Photos in Slideshow
+            <span class="text-neutral-400 font-normal" data-slideshow-editor-target="photoCount">(<%= @slideshow_uploads.size %>)</span>
+          </h2>
+        </div>
+
+        <% if @slideshow_uploads.any? %>
+          <div class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-3" data-slideshow-editor-target="photoGrid">
+            <% @slideshow_uploads.each do |slideshow_upload| %>
+              <% upload = slideshow_upload.upload %>
+              <% if upload.file.attached? %>
+                <div class="relative group aspect-square bg-neutral-100 rounded-lg overflow-hidden"
+                     data-upload-id="<%= upload.id %>">
+                  <%= image_tag upload_variant_url(upload, :thumb),
+                      class: "w-full h-full object-cover",
+                      alt: upload.title || "Photo" %>
+                  <div class="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                    <button type="button"
+                            class="p-2 bg-red-600 hover:bg-red-700 rounded-lg transition-colors"
+                            data-action="click->slideshow-editor#removePhoto"
+                            data-upload-id="<%= upload.id %>"
+                            title="Remove from slideshow">
+                      <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              <% end %>
+            <% end %>
+          </div>
+        <% else %>
+          <p class="text-neutral-500 text-sm py-8 text-center" data-slideshow-editor-target="emptyState">
+            No photos in this slideshow yet. Add some from your galleries below.
+          </p>
+        <% end %>
       </div>
 
-      <div class="flex items-center gap-3 pt-4">
-        <%= f.submit "Save Changes", class: "px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition-colors cursor-pointer" %>
-        <%= link_to "Cancel", slideshow_path(@slideshow), class: "px-4 py-2 text-neutral-600 hover:text-neutral-800 text-sm" %>
+      <!-- Add Photos from Galleries -->
+      <div class="bg-white rounded-xl border border-neutral-200 shadow-sm p-6">
+        <h2 class="text-lg font-semibold text-neutral-800 mb-4">Add Photos from Galleries</h2>
+
+        <% if @galleries.any? %>
+          <div class="space-y-4">
+            <% @galleries.each do |gallery| %>
+              <% gallery_uploads = gallery.uploads.select { |u| u.file.attached? } %>
+              <% next if gallery_uploads.empty? %>
+
+              <details class="group border border-neutral-200 rounded-lg">
+                <summary class="flex items-center justify-between p-4 cursor-pointer hover:bg-neutral-50 rounded-lg">
+                  <div class="flex items-center gap-3">
+                    <% if gallery_uploads.first %>
+                      <%= image_tag upload_variant_url(gallery_uploads.first, :thumb),
+                          class: "w-12 h-12 object-cover rounded-lg",
+                          alt: gallery.title %>
+                    <% else %>
+                      <div class="w-12 h-12 bg-neutral-200 rounded-lg flex items-center justify-center">
+                        <svg class="w-6 h-6 text-neutral-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+                        </svg>
+                      </div>
+                    <% end %>
+                    <div>
+                      <h3 class="font-medium text-neutral-800"><%= gallery.title %></h3>
+                      <p class="text-sm text-neutral-500"><%= pluralize(gallery_uploads.size, 'photo') %></p>
+                    </div>
+                  </div>
+                  <svg class="w-5 h-5 text-neutral-400 group-open:rotate-180 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                  </svg>
+                </summary>
+
+                <div class="p-4 pt-0 border-t border-neutral-100">
+                  <div class="grid grid-cols-4 sm:grid-cols-6 gap-2 mt-4">
+                    <% gallery_uploads.each do |upload| %>
+                      <% already_in_slideshow = @slideshow.upload_ids.include?(upload.id) %>
+                      <div class="relative aspect-square">
+                        <label class="block w-full h-full cursor-pointer <%= already_in_slideshow ? 'opacity-50' : '' %>">
+                          <input type="checkbox"
+                                 class="sr-only peer"
+                                 data-action="change->slideshow-editor#togglePhoto"
+                                 data-upload-id="<%= upload.id %>"
+                                 <%= 'checked disabled' if already_in_slideshow %>>
+                          <%= image_tag upload_variant_url(upload, :thumb),
+                              class: "w-full h-full object-cover rounded-lg transition-all peer-checked:ring-2 peer-checked:ring-blue-500 peer-checked:ring-offset-2",
+                              alt: upload.title || "Photo" %>
+                          <div class="absolute inset-0 rounded-lg bg-blue-500/20 opacity-0 peer-checked:opacity-100 transition-opacity flex items-center justify-center">
+                            <svg class="w-6 h-6 text-blue-600" fill="currentColor" viewBox="0 0 24 24">
+                              <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z"/>
+                            </svg>
+                          </div>
+                          <% if already_in_slideshow %>
+                            <div class="absolute top-1 right-1 bg-green-500 text-white text-xs px-1.5 py-0.5 rounded">
+                              Added
+                            </div>
+                          <% end %>
+                        </label>
+                      </div>
+                    <% end %>
+                  </div>
+                </div>
+              </details>
+            <% end %>
+          </div>
+        <% else %>
+          <p class="text-neutral-500 text-sm py-4">
+            No galleries found. <%= link_to "Create a gallery", new_gallery_path, class: "text-blue-600 hover:text-blue-700" %> first.
+          </p>
+        <% end %>
       </div>
-    <% end %>
+    </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,8 @@ Rails.application.routes.draw do
     end
     member do
       post :add_uploads
+      delete :remove_upload
+      patch :reorder_uploads
     end
   end
 

--- a/spec/requests/slideshows_spec.rb
+++ b/spec/requests/slideshows_spec.rb
@@ -176,6 +176,92 @@ RSpec.describe "Slideshows", type: :request do
     end
   end
 
+  describe "DELETE /slideshows/:id/remove_upload" do
+    let!(:slideshow) { create(:slideshow, user: user, title: "My Slideshow") }
+
+    before do
+      uploads.each_with_index do |upload, index|
+        slideshow.slideshow_uploads.create!(upload: upload, position: index)
+      end
+    end
+
+    it "removes an upload from the slideshow" do
+      expect {
+        delete remove_upload_slideshow_path(slideshow), params: {
+          upload_id: uploads.first.id
+        }, as: :json
+      }.to change { slideshow.uploads.count }.by(-1)
+
+      expect(response).to have_http_status(:success)
+      json = JSON.parse(response.body)
+      expect(json["success"]).to be true
+      expect(json["total_count"]).to eq(2)
+    end
+
+    it "does not delete the actual upload" do
+      expect {
+        delete remove_upload_slideshow_path(slideshow), params: {
+          upload_id: uploads.first.id
+        }, as: :json
+      }.not_to change(Upload, :count)
+    end
+
+    it "prevents removing from other user's slideshow" do
+      other_slideshow = create(:slideshow, user: other_user)
+
+      delete remove_upload_slideshow_path(other_slideshow), params: {
+        upload_id: uploads.first.id
+      }, as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "handles HTML format with redirect" do
+      delete remove_upload_slideshow_path(slideshow), params: {
+        upload_id: uploads.first.id
+      }
+
+      expect(response).to redirect_to(edit_slideshow_path(slideshow))
+    end
+  end
+
+  describe "PATCH /slideshows/:id/reorder_uploads" do
+    let!(:slideshow) { create(:slideshow, user: user, title: "My Slideshow") }
+
+    before do
+      uploads.each_with_index do |upload, index|
+        slideshow.slideshow_uploads.create!(upload: upload, position: index)
+      end
+    end
+
+    it "reorders uploads in the slideshow" do
+      reversed_ids = uploads.reverse.map(&:id)
+
+      patch reorder_uploads_slideshow_path(slideshow), params: {
+        upload_ids: reversed_ids
+      }, as: :json
+
+      expect(response).to have_http_status(:success)
+      json = JSON.parse(response.body)
+      expect(json["success"]).to be true
+
+      # Check new positions
+      slideshow.reload
+      ordered_uploads = slideshow.slideshow_uploads.order(:position).map(&:upload_id)
+      expect(ordered_uploads).to eq(reversed_ids)
+    end
+
+    it "prevents reordering other user's slideshow" do
+      other_slideshow = create(:slideshow, user: other_user)
+
+      patch reorder_uploads_slideshow_path(other_slideshow), params: {
+        upload_ids: uploads.map(&:id)
+      }, as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
   describe "admin access" do
     let(:admin) { create(:user, :admin) }
 


### PR DESCRIPTION
## Summary

- Add ability to view, add, and remove photos from existing slideshows
- Redesigned edit page with settings panel and photo management panel
- Gallery browser shows which photos are already in the slideshow

## Changes

- **Routes**: Added `remove_upload` and `reorder_uploads` member actions
- **SlideshowsController**: New actions for removing and reordering photos
- **Edit view**: Two-column layout with settings and photo management
- **Stimulus controller**: `slideshow_editor_controller.js` for AJAX interactions

## Screenshots

The edit page now shows:
- Current photos in slideshow with remove buttons (hover to reveal)
- Collapsible gallery sections to browse and add more photos
- "Added" badges on photos already in the slideshow

## Test plan

- [x] Remove photo from slideshow via UI
- [x] Add photo from gallery to slideshow
- [x] Cannot add same photo twice (shows as "Added")
- [x] All 197 tests pass
- [x] Rubocop clean
- [x] Brakeman clean

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)